### PR TITLE
Changing how Lambdas are normalized if Simplex=True

### DIFF
--- a/codes/IAE_JAX_v2_devl.py
+++ b/codes/IAE_JAX_v2_devl.py
@@ -734,8 +734,8 @@ class IAE(object):
             if not self.simplex:
                 B = params["Lambda"] @ self.PhiE
             else:
-                Lambda = params["Lambda"] / (np.sum(np.abs(params["Lambda"] ), axis=1)[:, np.newaxis] + 1e-3)
-                B = Lambda @ self.PhiE
+                params["Lambda"] = params["Lambda"] / (np.sum(params["Lambda"], axis=1)[:, np.newaxis] + 1e-3)
+                B = params["Lambda"] @ self.PhiE
 
             XRec = self.decoder(B)
 


### PR DESCRIPTION
When testing the IAE and the BSP on X-ray spectra, the BSP was giving strange spectra in ~5-10% of the cases.
Investigation revealed that this was due to the simplex constraint not being followed (Sum(Lambdas)>1) hence producing strange spectra as an output.

This PR modifies two things:
- Lambdas need to be divided by sum(L) not sum(abs(L))
- new Lambdas were not updated in params["Lambda"]

When testing Sum(L) is now 1 for the cases I tested  and BSP and FastInterp now provide consistent results.
